### PR TITLE
Fix issue #7: auto-login after registration

### DIFF
--- a/backend/__tests__/controllers/auth.test.js
+++ b/backend/__tests__/controllers/auth.test.js
@@ -82,6 +82,7 @@ describe("Auth Controller", () => {
         user_type: UserType.USER,
       };
 
+      prisma.user.findUnique.mockResolvedValue(null);
       prisma.user.create.mockResolvedValue(mockUser);
 
       // Execute
@@ -98,11 +99,19 @@ describe("Auth Controller", () => {
           password: "hashedpassword123",
           user_type: UserType.USER,
         },
+        select: { id: true, username: true, email: true, user_type: true },
       });
+
+      expect(jwt.sign).toHaveBeenCalledWith(
+        { id: 1, user_type: UserType.USER },
+        expect.any(String),
+        { expiresIn: "1h" }
+      );
 
       expect(res.status).toHaveBeenCalledWith(201);
       expect(res.json).toHaveBeenCalledWith({
         message: "User registered successfully",
+        token: "mocked-jwt-token",
         user: mockUser,
       });
     });
@@ -119,6 +128,7 @@ describe("Auth Controller", () => {
         user_type: UserType.PHOTOGRAPHER,
       };
 
+      prisma.user.findUnique.mockResolvedValue(null);
       prisma.user.create.mockResolvedValue(mockUser);
 
       // Execute
@@ -129,11 +139,19 @@ describe("Auth Controller", () => {
         data: expect.objectContaining({
           user_type: UserType.PHOTOGRAPHER,
         }),
+        select: { id: true, username: true, email: true, user_type: true },
       });
+
+      expect(jwt.sign).toHaveBeenCalledWith(
+        { id: 1, user_type: UserType.PHOTOGRAPHER },
+        expect.any(String),
+        { expiresIn: "1h" }
+      );
 
       expect(res.status).toHaveBeenCalledWith(201);
       expect(res.json).toHaveBeenCalledWith({
         message: "User registered successfully",
+        token: "mocked-jwt-token",
         user: mockUser,
       });
     });

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -42,9 +42,15 @@ export const registerUser = async (req, res) => {
       select: { id: true, username: true, email: true, user_type: true }
     });
 
+    const token = jwt.sign(
+      { id: user.id, user_type: user.user_type },
+      JWT_SECRET,
+      { expiresIn: "1h" }
+    );
+
     return res
       .status(201)
-      .json({ message: "User registered successfully", user });
+      .json({ message: "User registered successfully", token, user });
   } catch (error) {
     console.error("Registration Error:", error);
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
+    "dev": "nodemon server.js",
     "prisma:migrate": "npx prisma migrate dev --name ${npm_config_name:-init}",
     "prisma:seed": "npx prisma db seed",
     "prisma:reset": "npx prisma migrate reset --force",

--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -31,8 +31,8 @@ test.describe('Authentication', () => {
         'USER'
       );
 
-      // Should redirect to login or show success message
-      await expect(page).toHaveURL(/\/(login|home)/);
+      // Should redirect to discover after auto-login
+      await expect(page).toHaveURL(/\/discover/);
     });
 
     test('should register a new photographer successfully', async ({ page }) => {
@@ -48,8 +48,8 @@ test.describe('Authentication', () => {
         'PHOTOGRAPHER'
       );
 
-      // Should redirect to login or show success message
-      await expect(page).toHaveURL(/\/(login|home)/);
+      // Should redirect to photographer dashboard after auto-login
+      await expect(page).toHaveURL(/\/profile-dashboard/);
     });
 
     test('should show error for duplicate email', async ({ page }) => {

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { registerUser } from "../api/client";
+import { useAuth } from "../context/AuthContext";
 import { Eye, EyeOff } from "lucide-react";
 
 function Register() {
+  const { login } = useAuth();
   const [formData, setFormData] = useState({
     username: "",
     email: "",
@@ -47,9 +49,13 @@ function Register() {
     setError(null);
 
     try {
-      await registerUser(formData);
-      alert("Registration successful! You can now log in.");
-      navigate("/");
+      const data = await registerUser(formData);
+      login(data.user, data.token);
+      if (data.user.user_type === "PHOTOGRAPHER") {
+        navigate("/profile-dashboard");
+      } else {
+        navigate("/discover");
+      }
     } catch (error) {
       setError(error.message);
     } finally {


### PR DESCRIPTION
## Summary

- Backend now generates and returns a JWT token in the `201` registration response
- Frontend calls `login(user, token)` immediately after registration, skipping the manual login step
- Users are redirected to `/discover` (USER) or `/profile-dashboard` (PHOTOGRAPHER) with an active session
- Removed the blocking `alert()` dialog
- Added `nodemon` dev script to backend for hot reloading

## Test plan

- [ ] Register as a USER → lands on `/discover` without alert, session persists on refresh
- [ ] Register as a PHOTOGRAPHER → lands on `/profile-dashboard` without alert, session persists on refresh
- [ ] Run `cd backend && npm test` — the 2 updated registration happy-path tests pass
- [ ] Run `npm run e2e` — the 2 updated registration redirect assertions pass

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)