### PR TITLE
feat(auth): split card role selection signup flow

### DIFF
--- a/e2e/pages/RegisterPage.js
+++ b/e2e/pages/RegisterPage.js
@@ -6,8 +6,9 @@ export class RegisterPage extends BasePage {
     this.usernameInput = '[data-testid="username-input"]';
     this.emailInput = '[data-testid="email-input"]';
     this.passwordInput = '[data-testid="password-input"]';
-    this.userTypeSelect = '[data-testid="user-type-select"]';
-    this.registerButton = '[data-testid="register-button"]';
+    this.continueButton = '[data-testid="continue-button"]';
+    this.roleUserCard = '[data-testid="role-user-card"]';
+    this.rolePhotographerCard = '[data-testid="role-photographer-card"]';
     this.loginLink = '[data-testid="login-link"]';
     this.errorMessage = '[data-testid="error-message"]';
     this.successMessage = '[data-testid="success-message"]';
@@ -23,8 +24,12 @@ export class RegisterPage extends BasePage {
     await this.fill(this.usernameInput, username);
     await this.fill(this.emailInput, email);
     await this.fill(this.passwordInput, password);
-    await this.page.selectOption(this.userTypeSelect, userType);
-    await this.click(this.registerButton);
+    await this.click(this.continueButton);
+    if (userType === 'PHOTOGRAPHER') {
+      await this.click(this.rolePhotographerCard);
+    } else {
+      await this.click(this.roleUserCard);
+    }
   }
 
   async getErrorMessage() {

--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -72,7 +72,7 @@ test.describe('Authentication', () => {
       await registerPage.goto();
 
       // Try to register without filling all fields
-      await page.click('[data-testid="register-button"]');
+      await page.click('[data-testid="continue-button"]');
 
       // Should stay on register page and show validation errors
       expect(await registerPage.isRegisterFormVisible()).toBeTruthy();

--- a/frontend/src/components/RoleSelectionCards.jsx
+++ b/frontend/src/components/RoleSelectionCards.jsx
@@ -1,0 +1,66 @@
+import { Users, Camera, ArrowLeft } from "lucide-react";
+
+function RoleSelectionCards({ onSelect, onBack, isLoading }) {
+  return (
+    <div className="flex flex-col items-center">
+      <h3 className="text-xl font-semibold text-gray-800 mb-2">
+        What brings you here?
+      </h3>
+      <p className="text-sm text-gray-500 mb-8">Choose how you'll use PhotoBook</p>
+
+      <div className="flex flex-col sm:flex-row gap-4 w-full">
+        <button
+          data-testid="role-user-card"
+          onClick={() => onSelect("USER")}
+          disabled={isLoading}
+          className="flex-1 flex flex-col items-center gap-4 p-8 border-2 border-gray-200 rounded-xl hover:border-indigo-500 hover:shadow-md transition-all duration-200 bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <div className="p-4 bg-indigo-50 rounded-full">
+            <Users className="h-10 w-10 text-indigo-600" />
+          </div>
+          <div className="text-center">
+            <p className="text-lg font-bold text-gray-900">I'm looking to hire</p>
+            <p className="text-sm text-gray-500 mt-1">
+              Browse photographers and book sessions
+            </p>
+          </div>
+        </button>
+
+        <button
+          data-testid="role-photographer-card"
+          onClick={() => onSelect("PHOTOGRAPHER")}
+          disabled={isLoading}
+          className="flex-1 flex flex-col items-center gap-4 p-8 border-2 border-gray-200 rounded-xl hover:border-indigo-500 hover:shadow-md transition-all duration-200 bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <div className="p-4 bg-indigo-50 rounded-full">
+            <Camera className="h-10 w-10 text-indigo-600" />
+          </div>
+          <div className="text-center">
+            <p className="text-lg font-bold text-gray-900">I'm a photographer</p>
+            <p className="text-sm text-gray-500 mt-1">
+              Showcase your work and manage bookings
+            </p>
+          </div>
+        </button>
+      </div>
+
+      {isLoading && (
+        <p className="mt-6 text-sm text-indigo-600 animate-pulse">
+          Creating your account...
+        </p>
+      )}
+
+      <button
+        data-testid="role-back-button"
+        onClick={onBack}
+        disabled={isLoading}
+        className="mt-6 flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Go back
+      </button>
+    </div>
+  );
+}
+
+export default RoleSelectionCards;

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from "react-router-dom";
 import { registerUser } from "../api/client";
 import { useAuth } from "../context/AuthContext";
 import { Eye, EyeOff } from "lucide-react";
+import RoleSelectionCards from "../components/RoleSelectionCards";
 
 function Register() {
   const { login } = useAuth();
@@ -12,6 +13,7 @@ function Register() {
     password: "",
     user_type: "USER",
   });
+  const [step, setStep] = useState(1);
   const [error, setError] = useState(null);
   const [passwordError, setPasswordError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -21,6 +23,7 @@ function Register() {
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData({ ...formData, [name]: value });
+    setError(null);
     if (name === "password") {
       validatePassword(value);
     }
@@ -40,24 +43,31 @@ function Register() {
     }
   };
 
-  const handleRegisterSubmit = async (e) => {
+  const handleContinue = (e) => {
     e.preventDefault();
-    if (passwordError) {
+    if (!formData.username || !formData.email || !formData.password || passwordError) {
       return;
     }
+    setError(null);
+    setStep(2);
+  };
+
+  const handleRoleSelect = async (selectedRole) => {
+    const finalFormData = { ...formData, user_type: selectedRole };
     setIsLoading(true);
     setError(null);
 
     try {
-      const data = await registerUser(formData);
+      const data = await registerUser(finalFormData);
       login(data.user, data.token);
-      if (data.user.user_type === "PHOTOGRAPHER") {
+      if (selectedRole === "PHOTOGRAPHER") {
         navigate("/profile-dashboard");
       } else {
         navigate("/discover");
       }
     } catch (error) {
       setError(error.message);
+      setStep(1);
     } finally {
       setIsLoading(false);
     }
@@ -87,145 +97,134 @@ function Register() {
             </div>
           )}
 
-          <form data-testid="register-form" className="space-y-6" onSubmit={handleRegisterSubmit}>
-            <div>
-              <label
-                htmlFor="username"
-                className="block text-sm font-medium text-gray-700"
-              >
-                Username
-              </label>
-              <div className="mt-1">
-                <input
-                  id="username"
-                  name="username"
-                  type="text"
-                  required
-                  data-testid="username-input"
-                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-                  value={formData.username}
-                  onChange={handleChange}
-                />
-              </div>
-            </div>
-
-            <div>
-              <label
-                htmlFor="email"
-                className="block text-sm font-medium text-gray-700"
-              >
-                Email address
-              </label>
-              <div className="mt-1">
-                <input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  required
-                  data-testid="email-input"
-                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-                  value={formData.email}
-                  onChange={handleChange}
-                />
-              </div>
-            </div>
-
-            <div>
-              <label
-                htmlFor="password"
-                className="block text-sm font-medium text-gray-700"
-              >
-                Password
-              </label>
-              <div className="mt-1 relative">
-                <input
-                  id="password"
-                  name="password"
-                  type={showPassword ? "text" : "password"}
-                  autoComplete="new-password"
-                  required
-                  data-testid="password-input"
-                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm pr-10"
-                  value={formData.password}
-                  onChange={handleChange}
-                />
-                <button
-                  type="button"
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
-                  onClick={toggleShowPassword}
+          {step === 1 && (
+            <form data-testid="register-form" className="space-y-6" onSubmit={handleContinue}>
+              <div>
+                <label
+                  htmlFor="username"
+                  className="block text-sm font-medium text-gray-700"
                 >
-                  {showPassword ? (
-                    <EyeOff className="h-5 w-5 text-gray-400" />
-                  ) : (
-                    <Eye className="h-5 w-5 text-gray-400" />
-                  )}
+                  Username
+                </label>
+                <div className="mt-1">
+                  <input
+                    id="username"
+                    name="username"
+                    type="text"
+                    required
+                    data-testid="username-input"
+                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                    value={formData.username}
+                    onChange={handleChange}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="email"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Email address
+                </label>
+                <div className="mt-1">
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    autoComplete="email"
+                    required
+                    data-testid="email-input"
+                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                    value={formData.email}
+                    onChange={handleChange}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="password"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Password
+                </label>
+                <div className="mt-1 relative">
+                  <input
+                    id="password"
+                    name="password"
+                    type={showPassword ? "text" : "password"}
+                    autoComplete="new-password"
+                    required
+                    data-testid="password-input"
+                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm pr-10"
+                    value={formData.password}
+                    onChange={handleChange}
+                  />
+                  <button
+                    type="button"
+                    className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                    onClick={toggleShowPassword}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-5 w-5 text-gray-400" />
+                    ) : (
+                      <Eye className="h-5 w-5 text-gray-400" />
+                    )}
+                  </button>
+                </div>
+                {passwordError && (
+                  <p className="mt-2 text-sm text-red-600" id="password-error">
+                    {passwordError}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <button
+                  type="submit"
+                  data-testid="continue-button"
+                  className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                  disabled={!!passwordError}
+                >
+                  Continue
                 </button>
               </div>
-              {passwordError && (
-                <p className="mt-2 text-sm text-red-600" id="password-error">
-                  {passwordError}
-                </p>
-              )}
-            </div>
+            </form>
+          )}
 
-            <div>
-              <label
-                htmlFor="user_type"
-                className="block text-sm font-medium text-gray-700"
-              >
-                User Type
-              </label>
-              <div className="mt-1">
-                <select
-                  id="user_type"
-                  name="user_type"
-                  data-testid="user-type-select"
-                  className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-                  value={formData.user_type}
-                  onChange={handleChange}
-                  required
-                >
-                  <option value="USER">User</option>
-                  <option value="PHOTOGRAPHER">Photographer</option>
-                </select>
-              </div>
-            </div>
+          {step === 2 && (
+            <RoleSelectionCards
+              onSelect={handleRoleSelect}
+              onBack={() => setStep(1)}
+              isLoading={isLoading}
+            />
+          )}
 
-            <div>
-              <button
-                type="submit"
-                data-testid="register-button"
-                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                disabled={isLoading || !!passwordError}
-              >
-                {isLoading ? "Signing up..." : "Sign up"}
-              </button>
-            </div>
-          </form>
-
-          <div className="mt-6">
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-gray-300"></div>
-              </div>
-              <div className="relative flex justify-center text-sm">
-                <span className="px-2 bg-white text-gray-500">
-                  Already have an account?
-                </span>
-              </div>
-            </div>
-
+          {step === 1 && (
             <div className="mt-6">
-              <Link
-                to="/login"
-                data-testid="login-link"
-                className="w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50"
-              >
-                Log in
-              </Link>
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <div className="w-full border-t border-gray-300"></div>
+                </div>
+                <div className="relative flex justify-center text-sm">
+                  <span className="px-2 bg-white text-gray-500">
+                    Already have an account?
+                  </span>
+                </div>
+              </div>
+
+              <div className="mt-6">
+                <Link
+                  to="/login"
+                  data-testid="login-link"
+                  className="w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50"
+                >
+                  Log in
+                </Link>
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Replaces the buried `user_type` dropdown on the signup form with a full-screen, two-step card selection flow
- Step 1: user fills in username, email, and password, then clicks **Continue** (no API call yet)
- Step 2: two large visual cards appear — "I'm looking to hire" (USER) and "I'm a photographer" (PHOTOGRAPHER) — user clicks one to complete registration
- Fixes a bug where the "email already exists" error banner persisted after the user corrected their email; error now clears on any field edit or on Continue click
- Updates the E2E page object (`RegisterPage.js`) and auth spec (`auth.spec.js`) to match the new two-step flow

## Test plan

- [x] Navigate to `/register` — confirm no dropdown is visible
- [x] Happy path (USER): fill credentials → Continue → click "I'm looking to hire" → confirm redirect to `/discover`
- [x] Happy path (PHOTOGRAPHER): repeat with new email → click "I'm a photographer" → confirm redirect to `/profile-dashboard`
- [x] Back navigation: reach Step 2, click "Go back", confirm credentials fields are still populated
- [x] Weak password blocks Continue: type `abc`, confirm button stays disabled
- [x] Duplicate email error: register same email twice, confirm error banner appears on Step 1 after selecting a card, and clears as soon as the email field is edited
- [ ] Run `npm run e2e` from project root — all auth tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)