### PR TITLE
feat(console): add console application project

### DIFF
--- a/PhotoFinder.Api/PhotoFinderAPI.Console/PhotoFinderAPI.Console.csproj
+++ b/PhotoFinder.Api/PhotoFinderAPI.Console/PhotoFinderAPI.Console.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/PhotoFinder.Api/PhotoFinderAPI.Console/Program.cs
+++ b/PhotoFinder.Api/PhotoFinderAPI.Console/Program.cs
@@ -1,0 +1,15 @@
+Console.WriteLine("PhotoFinderAPI Console Application");
+Console.WriteLine("==================================");
+
+// TODO: Start writing your custom code below this line
+var test = new Test();
+Console.WriteLine(test);
+
+
+
+// all class definitions go below their usage.
+public class Test
+{
+}
+
+

--- a/PhotoFinder.Api/PhotoFinderAPI.sln
+++ b/PhotoFinder.Api/PhotoFinderAPI.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotoFinderAPI", "PhotoFind
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotoFinderAPI.Tests", "PhotoFinderAPI.Tests\PhotoFinderAPI.Tests.csproj", "{2EA7CD61-15D5-4D5E-B8C6-FC64FD0BA8A1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotoFinderAPI.Console", "PhotoFinderAPI.Console\PhotoFinderAPI.Console.csproj", "{D96FF1A6-44CE-4B5A-B146-764ACC14132D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,18 @@ Global
 		{2EA7CD61-15D5-4D5E-B8C6-FC64FD0BA8A1}.Release|x64.Build.0 = Release|Any CPU
 		{2EA7CD61-15D5-4D5E-B8C6-FC64FD0BA8A1}.Release|x86.ActiveCfg = Release|Any CPU
 		{2EA7CD61-15D5-4D5E-B8C6-FC64FD0BA8A1}.Release|x86.Build.0 = Release|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Debug|x64.Build.0 = Debug|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Debug|x86.Build.0 = Debug|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Release|x64.ActiveCfg = Release|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Release|x64.Build.0 = Release|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Release|x86.ActiveCfg = Release|Any CPU
+		{D96FF1A6-44CE-4B5A-B146-764ACC14132D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- Added a new .NET 9.0 console application (`PhotoFinderAPI.Console`) to the PhotoFinderAPI solution
- Includes minimal starter code with a TODO comment for writing custom code
- Registered the new project in `PhotoFinderAPI.sln`

## Test plan
- [ ] Run `dotnet build PhotoFinderAPI.Console/PhotoFinderAPI.Console.csproj` from `PhotoFinder.Api/` — should build successfully
- [ ] Run `dotnet run --project PhotoFinderAPI.Console/PhotoFinderAPI.Console.csproj` — should print output to console
- [ ] Open `PhotoFinderAPI.sln` in IDE and confirm all three projects load

🤖 Generated with [Claude Code](https://claude.com/claude-code)