### PR TITLE
feat(tests): add FluentAssertions photographer controller tests

### DIFF
--- a/PhotoFinder.Api/PhotoFinderAPI.Tests/PhotoFinderAPI.Tests.csproj
+++ b/PhotoFinder.Api/PhotoFinderAPI.Tests/PhotoFinderAPI.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/PhotoFinder.Api/PhotoFinderAPI.Tests/PhotographerControllerFluentTests.cs
+++ b/PhotoFinder.Api/PhotoFinderAPI.Tests/PhotographerControllerFluentTests.cs
@@ -1,0 +1,64 @@
+using PhotoFinderAPI.Controllers;
+using PhotoFinderAPI.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PhotoFinderAPI.Tests;
+
+public class PhotographerControllerFluentTests
+{
+    private readonly PhotographersController _controller;
+
+    public PhotographerControllerFluentTests()
+    {
+        // AAA (Arrange/Act/Assert)
+        // Arrange: create a controller with a fake service
+        var fakeService = new FakePhotographerService();
+        _controller = new PhotographersController(fakeService);
+    }
+
+    [Fact]
+    public void GetAll_ReturnsListOfPhotographers()
+    {
+        // Act: call the method
+        var result = _controller.GetAll();
+
+        // Assert: check the result using FluentAssertions
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var photographers = okResult.Value.Should().BeOfType<List<Photographer>>().Subject;
+        photographers.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void GetById_WithValidId_ReturnsPhotographer()
+    {
+        // Act: call the method
+        var result = _controller.GetById(1);
+
+        // Assert: check the result using FluentAssertions
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var photographer = okResult.Value.Should().BeOfType<Photographer>().Subject;
+        photographer.Name.Should().Be("Test Photographer");
+    }
+
+    [Fact]
+    public void GetById_WithInvalidId_ReturnsNotFound()
+    {
+        // Act: call the method
+        var result = _controller.GetById(-1);
+
+        // Assert: check the result using FluentAssertions
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public void Create_AddsPhotographerAndReturnsCreated()
+    {
+        var newPhotographer = new Photographer{Bio = "test bio", Id = 3, Location = "PA", Name = "Create test", Rating = 1, Style = "sports"};
+        var response = _controller.Create(newPhotographer);
+
+        var result = response.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        var photographer = result.Value.Should().BeOfType<Photographer>().Subject;
+        photographer.Bio.Should().Be(newPhotographer.Bio);
+    }
+}


### PR DESCRIPTION
## Summary
- Added **FluentAssertions 8.9.0** NuGet package to the test project
- Created `PhotographerControllerFluentTests.cs` that mirrors all 4 existing xUnit assertion tests using fluent syntax
- All 8 tests pass (4 original + 4 fluent)

## Test plan
- [x] `dotnet test` passes with all 8 tests green
- [x] Verify tests run in CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)