### PR TITLE
fix: sync stale tests and resolve frontend lint errors

### DIFF
--- a/backend/__tests__/controllers/auth.test.js
+++ b/backend/__tests__/controllers/auth.test.js
@@ -156,7 +156,7 @@ describe("Auth Controller", () => {
       });
     });
 
-    it("should return 401 with invalid user_type", async () => {
+    it("should return 400 with invalid user_type", async () => {
       // Set invalid user_type
       req.body.user_type = "invalid_type";
 
@@ -164,9 +164,9 @@ describe("Auth Controller", () => {
       await authController.registerUser(req, res);
 
       // Assert
-      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({
-        error: "Invalid user_type on user",
+        message: "Invalid user_type on user",
       });
       expect(prisma.user.create).not.toHaveBeenCalled();
     });
@@ -174,14 +174,14 @@ describe("Auth Controller", () => {
     it('should handle database errors during registration', async () => {
         // Setup mock to throw error
         prisma.user.create.mockRejectedValue(new Error('Database error'));
-        
+
         // Execute
         await authController.registerUser(req, res);
-        
+
         // Assert
         expect(console.error).toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(500);
-        expect(res.json).toHaveBeenCalledWith({ error: 'Registration failed' });
+        expect(res.json).toHaveBeenCalledWith({ message: 'Registration failed. Please try again later.' });
       });
   });
 

--- a/backend/__tests__/controllers/photo.test.js
+++ b/backend/__tests__/controllers/photo.test.js
@@ -85,7 +85,7 @@ describe("Photo Controller", () => {
       // Assert
       expect(prisma.photo.findMany).toHaveBeenCalledWith({
         include: {
-          user: {
+          photographer: {
             select: {
               id: true,
               username: true,
@@ -229,7 +229,7 @@ describe("Photo Controller", () => {
           photo_type: "PORTRAIT",
         },
         include: {
-          user: {
+          photographer: {
             select: {
               id: true,
               username: true,

--- a/backend/__tests__/controllers/users.test.js
+++ b/backend/__tests__/controllers/users.test.js
@@ -4,7 +4,7 @@ import bcrypt from "bcryptjs";
 jest.mock("../../prisma/client.js", () => ({
   __esModule: true,
   default: {
-    User: {
+    user: {
       findMany: jest.fn(),
       findUnique: jest.fn(),
       create: jest.fn(),
@@ -55,20 +55,20 @@ describe("User Controller", () => {
         { id: 2, username: "user2", email: "user2@example.com" },
       ];
 
-      prisma.User.findMany.mockResolvedValue(mockUsers);
+      prisma.user.findMany.mockResolvedValue(mockUsers);
 
       // Act
       await userController.getAllUsers(req, res);
 
       // Assert
-      expect(prisma.User.findMany).toHaveBeenCalledTimes(1);
+      expect(prisma.user.findMany).toHaveBeenCalledTimes(1);
       expect(res.json).toHaveBeenCalledWith(mockUsers);
     });
 
     it("should handle errors", async () => {
       // Setup mock to throw error
       const errorMsg = "Database connection failed";
-      prisma.User.findMany.mockRejectedValue(new Error(errorMsg));
+      prisma.user.findMany.mockRejectedValue(new Error(errorMsg));
 
       // Execute
       await userController.getAllUsers(req, res);
@@ -87,13 +87,13 @@ describe("User Controller", () => {
       req.params.id = "1";
 
       // Setup mock
-      prisma.User.findUnique.mockResolvedValue(mockUser);
+      prisma.user.findUnique.mockResolvedValue(mockUser);
 
       // Execute
       await userController.getUserById(req, res);
 
       // Assert
-      expect(prisma.User.findUnique).toHaveBeenCalledWith({
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
         where: { id: 1 },
       });
       expect(res.json).toHaveBeenCalledWith(mockUser);
@@ -102,7 +102,7 @@ describe("User Controller", () => {
     it("should return 400 when user is not found", async () => {
       // Arrange
       req.params.id = "999";
-      prisma.User.findUnique.mockResolvedValue(null);
+      prisma.user.findUnique.mockResolvedValue(null);
 
       // Act
       await userController.getUserById(req, res);
@@ -115,7 +115,7 @@ describe("User Controller", () => {
     it("should handle errors", async () => {
       // Arrange
       req.params.id = "1";
-      prisma.User.findUnique.mockRejectedValue(new Error("Database error"));
+      prisma.user.findUnique.mockRejectedValue(new Error("Database error"));
 
       // Act
       await userController.getUserById(req, res);
@@ -145,7 +145,7 @@ describe("User Controller", () => {
       };
 
       // Setup mock
-      prisma.User.create.mockResolvedValue(mockCreatedUser);
+      prisma.user.create.mockResolvedValue(mockCreatedUser);
 
       // Execute
       await userController.createUser(req, res);
@@ -154,7 +154,7 @@ describe("User Controller", () => {
       expect(bcrypt.genSalt).toHaveBeenCalledWith(10);
       expect(bcrypt.hash).toHaveBeenCalledWith("password123", "mockedsalt");
 
-      expect(prisma.User.create).toHaveBeenCalledWith({
+      expect(prisma.user.create).toHaveBeenCalledWith({
         data: {
           username: "newuser",
           email: "newuser@example.com",
@@ -183,7 +183,7 @@ describe("User Controller", () => {
       expect(res.json).toHaveBeenCalledWith({
         error: "Missing required fields",
       });
-      expect(prisma.User.create).not.toHaveBeenCalled();
+      expect(prisma.user.create).not.toHaveBeenCalled();
     });
 
     it("should handle database errors", async () => {
@@ -196,7 +196,7 @@ describe("User Controller", () => {
       };
 
       // Setup mock to throw error
-      prisma.User.create.mockRejectedValue(
+      prisma.user.create.mockRejectedValue(
         new Error("Unique constraint failed on email")
       );
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -7,6 +7,12 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 export default [
   { ignores: ['dist'] },
   {
+    files: ['vite.config.js'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
+  {
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,

--- a/frontend/src/components/Gallery/Gallery.jsx
+++ b/frontend/src/components/Gallery/Gallery.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import { fetchAllPhotos } from "../../api/client";
 import { Camera, Filter } from "lucide-react";
 
@@ -109,6 +110,10 @@ const Gallery = ({ onPhotoClick }) => {
       )}
     </div>
   );
+};
+
+Gallery.propTypes = {
+  onPhotoClick: PropTypes.func.isRequired,
 };
 
 export default Gallery;

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,4 +1,5 @@
 import { Navigate } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
 const ProtectedRoute = ({
     element,
@@ -15,6 +16,13 @@ const ProtectedRoute = ({
     }
 
     return element;
+};
+
+ProtectedRoute.propTypes = {
+    element: PropTypes.element.isRequired,
+    allowedUserTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
+    authenticationStatus: PropTypes.bool.isRequired,
+    userType: PropTypes.string,
 };
 
 export default ProtectedRoute;

--- a/frontend/src/components/RoleSelectionCards.jsx
+++ b/frontend/src/components/RoleSelectionCards.jsx
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import { Users, Camera, ArrowLeft } from "lucide-react";
 
 function RoleSelectionCards({ onSelect, onBack, isLoading }) {
@@ -6,7 +7,7 @@ function RoleSelectionCards({ onSelect, onBack, isLoading }) {
       <h3 className="text-xl font-semibold text-gray-800 mb-2">
         What brings you here?
       </h3>
-      <p className="text-sm text-gray-500 mb-8">Choose how you'll use PhotoBook</p>
+      <p className="text-sm text-gray-500 mb-8">Choose how you&apos;ll use PhotoBook</p>
 
       <div className="flex flex-col sm:flex-row gap-4 w-full">
         <button
@@ -19,7 +20,7 @@ function RoleSelectionCards({ onSelect, onBack, isLoading }) {
             <Users className="h-10 w-10 text-indigo-600" />
           </div>
           <div className="text-center">
-            <p className="text-lg font-bold text-gray-900">I'm looking to hire</p>
+            <p className="text-lg font-bold text-gray-900">I&apos;m looking to hire</p>
             <p className="text-sm text-gray-500 mt-1">
               Browse photographers and book sessions
             </p>
@@ -36,7 +37,7 @@ function RoleSelectionCards({ onSelect, onBack, isLoading }) {
             <Camera className="h-10 w-10 text-indigo-600" />
           </div>
           <div className="text-center">
-            <p className="text-lg font-bold text-gray-900">I'm a photographer</p>
+            <p className="text-lg font-bold text-gray-900">I&apos;m a photographer</p>
             <p className="text-sm text-gray-500 mt-1">
               Showcase your work and manage bookings
             </p>
@@ -62,5 +63,11 @@ function RoleSelectionCards({ onSelect, onBack, isLoading }) {
     </div>
   );
 }
+
+RoleSelectionCards.propTypes = {
+  onSelect: PropTypes.func.isRequired,
+  onBack: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool,
+};
 
 export default RoleSelectionCards;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
+import PropTypes from "prop-types";
 import * as jwt_decode from "jwt-decode";
 
 const AuthContext = createContext(null);
@@ -81,6 +82,10 @@ export const AuthProvider = ({ children }) => {
       {children}
     </AuthContext.Provider>
   );
+};
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired,
 };
 
 export const useAuth = () => {


### PR DESCRIPTION
## Summary
- **Backend tests (38/38 passing)**: Updated 3 test files that were out of sync after recent controller refactors — fixed relation name (`user` → `photographer`), Prisma model casing (`User` → `user`), status codes (`401` → `400`), and error response format (`error` → `message`)
- **Frontend lint (0 errors)**: Added PropTypes to 4 components, escaped apostrophes in JSX, and configured ESLint flat config to recognize Node.js globals in `vite.config.js`

## Test plan
- [x] `npm test` in backend — 38/38 passing
- [x] `npm run lint` in frontend — 0 errors, 1 warning (expected react-refresh advisory)
- [x] `npm run build` in frontend — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)