### PR TITLE
Fix CORS for frontend → API (Vite proxy, CORS config, .NET policy)

### DIFF
--- a/PhotoFinder.Api/PhotoFinderAPI/Program.cs
+++ b/PhotoFinder.Api/PhotoFinderAPI/Program.cs
@@ -9,14 +9,22 @@ builder.Services.AddSwaggerGen();
 // Add services to the container.
 builder.Services.AddControllers();
 builder.Services.AddSingleton<IPhotographerService, PhotographerService>();
+
 // builder.Services.AddScoped<IPhotographerService, RealPhotographerService>();
+
+var corsOrigins =
+    builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+    ?? ["http://localhost:5173"];
 
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy("AllowFrontend", policy =>
-    {
-        policy.WithOrigins("http://localhost:5173").AllowAnyHeader().AllowAnyMethod();
-    });
+    options.AddPolicy(
+        "AllowFrontend",
+        policy =>
+        {
+            policy.WithOrigins(corsOrigins).AllowAnyHeader().AllowAnyMethod();
+        }
+    );
 });
 
 var app = builder.Build();
@@ -30,7 +38,7 @@ if (app.Environment.IsDevelopment())
 // Configure the HTTP request pipeline.
 app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
 app.UseMiddleware<RequestLoggingMiddleware>();
-app.UseCors("AllowFrontEnd");
+app.UseCors("AllowFrontend");
 app.UseHttpsRedirection();
 app.UseAuthorization();
 app.MapControllers();

--- a/PhotoFinder.Api/PhotoFinderAPI/appsettings.Development.json
+++ b/PhotoFinder.Api/PhotoFinderAPI/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Cors": {
+    "AllowedOrigins": [ "http://localhost:5173" ]
   }
 }

--- a/PhotoFinder.Api/PhotoFinderAPI/appsettings.json
+++ b/PhotoFinder.Api/PhotoFinderAPI/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": [ "http://localhost:5173" ]
+  }
 }

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,10 @@
 PORT=5002
 NODE_ENV=development
 
+# Optional: comma-separated browser origins allowed when not using a dev proxy (e.g. http://localhost:5173,http://127.0.0.1:5173).
+# If unset, the API allows any origin (origin: "*") for simple local setups.
+# CORS_ORIGINS=http://localhost:5173
+
 # Local PostgreSQL (running via Docker or Postgres.app)
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/my-database"
 DIRECT_URL="postgresql://postgres:postgres@localhost:5432/my-database"

--- a/backend/app.js
+++ b/backend/app.js
@@ -20,14 +20,28 @@ import authRoutes from "./routes/auth.js";
 const prisma = new PrismaClient();
 export const app = express();
 
+const corsMethods = "GET,POST,PUT,DELETE,PATCH,OPTIONS";
+const corsAllowedHeaders = "Content-Type,Authorization";
+
+const corsOriginsList = process.env.CORS_ORIGINS?.split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const corsOptions =
+  corsOriginsList?.length > 0
+    ? {
+        origin: corsOriginsList,
+        methods: corsMethods,
+        allowedHeaders: corsAllowedHeaders,
+      }
+    : {
+        origin: "*",
+        methods: corsMethods,
+        allowedHeaders: corsAllowedHeaders,
+      };
+
 // Middleware
-app.use(
-  cors({
-    origin: "*",
-    methods: "GET,POST,PUT,DELETE",
-    allowedHeaders: "Content-Type,Authorization",
-  })
-);
+app.use(cors(corsOptions));
 app.use(express.json({ limit: "50mb" }));
 app.use(express.urlencoded({ limit: "50mb", extended: true }));
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: ./frontend
       args:
-        # Using the public URL since requests will go through nginx
+        # Remote API: that host must send Access-Control-Allow-Origin for your real frontend origin, or use same-origin `/api` behind your gateway.
         - VITE_API_BASE_URL=https://photobook.kilometers.ai/api
     container_name: my-frontend
     networks:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,3 +1,5 @@
+# Static SPA only. API calls use VITE_API_BASE_URL at build time. Prefer same-origin `/api` behind a reverse proxy
+# (see repo nginx/nginx.conf) so the browser does not rely on cross-origin CORS for JSON APIs.
 server {
     listen 80;
     location / {

--- a/frontend/src/pages/Booking/Booking.test.jsx
+++ b/frontend/src/pages/Booking/Booking.test.jsx
@@ -70,13 +70,17 @@ describe("Booking Component", () => {
   });
 
   it("submits the form with correct data and navigates on success", async () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 14);
+    const futureDateStr = future.toISOString().split("T")[0];
+
     render(<Booking />);
 
     fireEvent.change(screen.getByLabelText("Session Type"), {
       target: { value: "family" },
     });
     fireEvent.change(screen.getByLabelText("Select Date"), {
-      target: { value: "2025-04-20" },
+      target: { value: futureDateStr },
     });
 
     await vi.waitFor(() => {
@@ -89,7 +93,7 @@ describe("Booking Component", () => {
 
     expect(bookingApi.createBooking).toHaveBeenCalledWith({
       bookingType: "family",
-      date: "2025-04-20",
+      date: futureDateStr,
       time: "10:00",
       photographer_id: 456,
       user_id: 123,

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,11 +7,28 @@ const envFile = `.env.${mode}`;
 import dotenv from "dotenv";
 dotenv.config({ path: envFile });
 
+// Default `/api` keeps the browser on the Vite origin and avoids CORS during local dev.
+// Override with VITE_API_BASE_URL (e.g. http://localhost:5002) if you want to hit the API directly.
+// If requests fail, check DevTools → Network: request URL, response CORS headers, and OPTIONS preflight.
+const apiBaseUrl = process.env.VITE_API_BASE_URL ?? "/api";
+
+const devProxyTarget =
+  process.env.VITE_DEV_PROXY_TARGET || "http://localhost:5002";
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   build: {
     sourcemap: true,
+  },
+  server: {
+    proxy: {
+      "/api": {
+        target: devProxyTarget,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
   },
   test: {
     globals: true,
@@ -20,8 +37,6 @@ export default defineConfig({
     css: false,
   },
   define: {
-    "import.meta.env.VITE_API_BASE_URL": JSON.stringify(
-      process.env.VITE_API_BASE_URL
-    ),
+    "import.meta.env.VITE_API_BASE_URL": JSON.stringify(apiBaseUrl),
   },
 });

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,8 +10,9 @@ http {
         server frontend:80;
     }
 
+    # Node backend listens on PORT inside the container (default 5004 in server.js; align with docker-compose).
     upstream backend {
-        server backend:3000;
+        server backend:5004;
     }
 
     server {
@@ -27,7 +28,8 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # Backend API
+        # Backend API — browser calls same origin (/api/...), so CORS is usually not required here.
+        # Do not add Access-Control-* headers in nginx if the app behind the proxy also sets them; duplicate CORS headers break browsers.
         location /api/ {
             rewrite ^/api/(.*) /$1 break;
             proxy_pass http://backend;


### PR DESCRIPTION
This pull request implements the CORS mitigation plan for the Photo Finder stack.

## Changes
- **Vite**: Default `VITE_API_BASE_URL` to `/api` with a dev server proxy to the Node backend (strip `/api` prefix). Optional `VITE_DEV_PROXY_TARGET` for non-default backend URLs.
- **Express**: Optional `CORS_ORIGINS` allowlist; widen allowed methods to include PATCH and OPTIONS when using the allowlist path.
- **.NET API**: Fix `UseCors` policy name (`AllowFrontend`) and load allowed origins from `Cors:AllowedOrigins` in appsettings.
- **Nginx**: Point upstream to backend port 5004; comments on avoiding duplicate CORS headers and same-origin `/api` usage.
- **Docker / SPA nginx**: Short comments on remote CORS vs same-origin API.
- **Tests**: Booking submit test uses a dynamic future date so validation passes regardless of current calendar date.

Made with [Cursor](https://cursor.com)